### PR TITLE
Feat: #17 Kafka 기본 구현

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,39 @@ services:
       MINIO_ROOT_PASSWORD: minioadmin  # Minio 로그인 비밀번호
     command: server /data --console-address ":9001"  # Minio 서버 실행 명령
 
+  zookeeper:
+    image: wurstmeister/zookeeper:latest
+    platform: linux/amd64
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+
+  kafka:
+    image: wurstmeister/kafka:latest
+    platform: linux/amd64
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_ADVERTISED_LISTENERS: INSIDE://kafka:29092,OUTSIDE://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT
+      KAFKA_LISTENERS: INSIDE://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092
+      KAFKA_INTER_BROKER_LISTENER_NAME: INSIDE
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    platform: linux/amd64
+    ports:
+      - "8080:8080"
+    environment:
+      KAFKA_CLUSTERS_0_NAME: local
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:29092
+      KAFKA_CLUSTERS_0_ZOOKEEPER: zookeeper:2181
+      KAFKA_CLUSTERS_0_READONLY: "false"
 volumes:
   server_data_db:
 

--- a/internal/build.gradle
+++ b/internal/build.gradle
@@ -24,6 +24,9 @@ repositories {
 }
 
 dependencies {
+	// kafka
+	implementation 'org.springframework.kafka:spring-kafka'
+
 	//minio
 	implementation 'io.minio:minio:8.5.0'
 	implementation 'com.squareup.okhttp3:okhttp:4.9.3'
@@ -35,6 +38,7 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.kafka:spring-kafka-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/internal/src/main/java/image/module/internal/ConsumerApplicationKafkaConfig.java
+++ b/internal/src/main/java/image/module/internal/ConsumerApplicationKafkaConfig.java
@@ -1,0 +1,48 @@
+package image.module.internal;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+
+// 이 클래스는 Kafka 컨슈머 설정을 위한 Spring 설정 클래스입니다.
+@EnableKafka // Kafka 리스너를 활성화하는 어노테이션입니다.
+@Configuration // Spring 설정 클래스로 선언하는 어노테이션입니다.
+public class ConsumerApplicationKafkaConfig {
+
+    // Kafka 컨슈머 팩토리를 생성하는 빈을 정의합니다.
+    // ConsumerFactory는 Kafka 컨슈머 인스턴스를 생성하는 데 사용됩니다.
+    // 각 컨슈머는 이 팩토리를 통해 생성된 설정을 기반으로 작동합니다.
+    @Bean
+    public ConsumerFactory<String, String> consumerFactory() {
+        // 컨슈머 팩토리 설정을 위한 맵을 생성합니다.
+        Map<String, Object> configProps = new HashMap<>();
+        // Kafka 브로커의 주소를 설정합니다.
+        configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        // 메시지 키의 디시리얼라이저 클래스를 설정합니다.
+        configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        // 메시지 값의 디시리얼라이저 클래스를 설정합니다.
+        configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        // 설정된 프로퍼티로 DefaultKafkaConsumerFactory를 생성하여 반환합니다.
+        return new DefaultKafkaConsumerFactory<>(configProps);
+    }
+
+    // Kafka 리스너 컨테이너 팩토리를 생성하는 빈을 정의합니다.
+    // ConcurrentKafkaListenerContainerFactory는 Kafka 메시지를 비동기적으로 수신하는 리스너 컨테이너를 생성하는 데 사용됩니다.
+    // 이 팩토리는 @KafkaListener 어노테이션이 붙은 메서드들을 실행할 컨테이너를 제공합니다.
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
+        // ConcurrentKafkaListenerContainerFactory를 생성합니다.
+        ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        // 컨슈머 팩토리를 리스너 컨테이너 팩토리에 설정합니다.
+        factory.setConsumerFactory(consumerFactory());
+        // 설정된 리스너 컨테이너 팩토리를 반환합니다.
+        return factory;
+    }
+}

--- a/internal/src/main/java/image/module/internal/ConsumerService.java
+++ b/internal/src/main/java/image/module/internal/ConsumerService.java
@@ -1,0 +1,20 @@
+package image.module.internal;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class ConsumerService {
+
+    // 이 메서드는 Kafka에서 메시지를 소비하는 리스너 메서드입니다.
+    // @KafkaListener 어노테이션은 이 메서드를 Kafka 리스너로 설정합니다.
+    @KafkaListener(topics = "image-upload-topic", groupId = "image-upload-group")
+    // Kafka 토픽 "test-topic"에서 메시지를 수신하면 이 메서드가 호출됩니다.
+    // groupId는 컨슈머 그룹을 지정하여 동일한 그룹에 속한 다른 컨슈머와 메시지를 분배받습니다.
+    public void listen(String message) {
+        System.out.println("Received Message in group 'image-upload-group': " + message);
+        // 메시지 처리 로직 추가
+    }
+}

--- a/internal/src/main/resources/application.yml
+++ b/internal/src/main/resources/application.yml
@@ -17,7 +17,11 @@ spring:
         use_sql_comments: true
         highlight_sql: true
     database-platform: org.hibernate.dialect.PostgreSQLDialect
-
+  kafka:
+    bootstrap-servers: localhost:9092
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
 server:
   port: 19094
 

--- a/upload/build.gradle
+++ b/upload/build.gradle
@@ -28,6 +28,9 @@ ext {
 }
 
 dependencies {
+    // kafka
+    implementation 'org.springframework.kafka:spring-kafka'
+
     //minio
     implementation 'io.minio:minio:8.5.0'
 
@@ -41,6 +44,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/upload/src/main/java/image/module/upload/ProducerApplicationKafkaConfig.java
+++ b/upload/src/main/java/image/module/upload/ProducerApplicationKafkaConfig.java
@@ -1,0 +1,28 @@
+package image.module.upload;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+@Configuration
+public class ProducerApplicationKafkaConfig {
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/upload/src/main/java/image/module/upload/UploadService.java
+++ b/upload/src/main/java/image/module/upload/UploadService.java
@@ -19,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -28,11 +29,12 @@ import org.springframework.web.multipart.MultipartFile;
 public class UploadService {
     private final MinioClient minioClient;
     private final ImageRepository imageRepository;
+    private final KafkaTemplate<String, String> kafkaTemplate;
 
     @Value("${minio.bucket}")
     private String bucketName;
 
-    //TODO: cdn_url 설정
+    //TODO: cdn_url 설정 uuid.png
     //이미지 데이터 db 저장
     public Image saveImageMetadata(MultipartFile file){
         Image image = Image.create(file);
@@ -54,5 +56,7 @@ public class UploadService {
         } catch (Exception e) {
             e.printStackTrace();
         }
+
+        kafkaTemplate.send("image-upload-topic", image.getStoredFileName());
     }
 }

--- a/upload/src/main/resources/application.yml
+++ b/upload/src/main/resources/application.yml
@@ -17,6 +17,11 @@ spring:
         use_sql_comments: true
         highlight_sql: true
     database-platform: org.hibernate.dialect.PostgreSQLDialect
+  kafka:
+    bootstrap-servers: localhost:9092
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
 
 server:
   port: 19092
@@ -39,5 +44,5 @@ logging:
 minio:
   url: http://localhost:9000
   accessKey: minio
-  secretKey: miniopass
+  secretKey: minioadmin
   bucket: mybucket


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #17

## 📝작업 내용

> kafka producer와 comsumer 기본 구현을 작업했습니다.
> 업로드시 치환된 이미지 이름을 internal 서버로 보냅니다.

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 카프카 설정파일


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for Kafka messaging with new services for Zookeeper, Kafka broker, and Kafka UI.
	- Integrated Kafka messaging capabilities into the image upload process.

- **Bug Fixes**
	- Corrected indentation in configuration files for clarity.

- **Documentation**
	- Updated comments in the UploadService class for better understanding.

- **Chores**
	- Updated configuration files to include new Kafka settings and adjusted MinIO secret key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->