### PR TITLE
Feat: #40 upload 응답 관련

### DIFF
--- a/upload/build.gradle
+++ b/upload/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:4.9.3'
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    //implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/upload/src/main/java/image/module/upload/application/UploadService.java
+++ b/upload/src/main/java/image/module/upload/application/UploadService.java
@@ -41,8 +41,8 @@ public class UploadService {
     private String cdnBaseUrl;
 
     //이미지 데이터 db 저장
-    public CompletableFuture<Void> saveImageMetadata(MultipartFile file) {
-        return CompletableFuture.runAsync(() -> {
+    public CompletableFuture<String> saveImageMetadata(MultipartFile file) {
+        return CompletableFuture.supplyAsync(() -> {
             try {
                 // 파일 데이터를 메모리에 저장
                 byte[] fileBytes = file.getBytes();
@@ -82,6 +82,7 @@ public class UploadService {
                 // 새롭게 InputStream을 생성하여 minio에 이미지 업로드
                 uploadImage(new ByteArrayInputStream(fileBytes), file.getContentType(), imageResponse);
 
+                return imageResponse.getOriginalFileUUID().toString();
             } catch (Exception e) {
                 log.error("이미지 메타데이터 저장 중 오류 발생: ", e);
                 throw new RuntimeException(e);

--- a/upload/src/main/java/image/module/upload/application/UploadService.java
+++ b/upload/src/main/java/image/module/upload/application/UploadService.java
@@ -3,20 +3,22 @@ package image.module.upload.application;
 import image.module.upload.util.FileUtil;
 import image.module.upload.domain.ImageExtension;
 import image.module.upload.infrastructure.DataService;
+import io.minio.GetObjectArgs;
 import io.minio.MinioClient;
 import io.minio.PutObjectArgs;
 import java.awt.image.BufferedImage;
-import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
 import javax.imageio.ImageIO;
 import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.kafka.core.KafkaTemplate;
-import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Retryable;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
@@ -33,61 +35,89 @@ public class UploadService {
     @Value("${cdn-server.url}")
     private String cdnBaseUrl;
 
-    //이미지 데이터 db 저장
-    @Transactional
-    public ImageResponse saveImageMetadata(MultipartFile file) throws Exception {
-        // 업로드 파일명을 불러옴
-        String originalName = file.getOriginalFilename();
+    public CompletableFuture<ImageResponse> saveImageMetadata(MultipartFile file) {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                // 업로드 파일명을 불러옴
+                String originalName = file.getOriginalFilename();
 
-        // 파일 이름이 존재하지 않는 경우
-        if(originalName == null) throw new IllegalArgumentException("잘못된 파일입니다.");
+                // 파일 이름이 존재하지 않는 경우
+                if (originalName == null) throw new IllegalArgumentException("잘못된 파일입니다.");
 
-        // test_image.jpg > [0] -> test_image, [1] -> jpg
-        String[] fileInfos = FileUtil.splitFileName(file.getOriginalFilename());
+                // 파일 정보 분리
+                String[] fileInfos = FileUtil.splitFileName(originalName);
 
-        // ImageExtension Enum 에 설정한 확장자가 아닌 경우는 업로드 하지 않음
-        ImageExtension extension = ImageExtension.findByKey(fileInfos[1])
-                .orElseThrow(() -> new Exception("지원하지 않는 확장자 입니다."));
+                // 확장자 체크
+                ImageExtension extension = ImageExtension.findByKey(fileInfos[1])
+                        .orElseThrow(() -> new Exception("지원하지 않는 확장자 입니다."));
 
-        int imageWidth = 0;
-        int imageHeight = 0;
-        try {
-            BufferedImage bufferedImage = ImageIO.read(file.getInputStream());
-            imageWidth = bufferedImage.getWidth();
-            imageHeight = bufferedImage.getHeight();
-        } catch (IOException e) {
-            log.error("IOException 발생: 이미지 입력 스트림을 읽을 수 없습니다.", e);
-        }
+                // 이미지 크기 확인
+                BufferedImage bufferedImage = ImageIO.read(file.getInputStream());
+                int imageWidth = bufferedImage.getWidth();
+                int imageHeight = bufferedImage.getHeight();
 
-        ImageRequest imageRequest = ImageRequest.create(
-                originalName,
-                extension.getKey(),
-                cdnBaseUrl,
-                imageWidth,
-                imageHeight
-        );
-        return dataService.uploadImage(imageRequest);
+                ImageRequest imageRequest = ImageRequest.create(
+                        originalName,
+                        extension.getKey(),
+                        cdnBaseUrl,
+                        imageWidth,
+                        imageHeight
+                );
+                return dataService.uploadImage(imageRequest);
+            } catch (Exception e) {
+                log.error("이미지 메타데이터 저장 중 오류 발생: ", e);
+                throw new RuntimeException(e);
+            }
+        });
     }
 
-    //이미지 업로드
-    @Async
+    // 이미지 업로드
     public void uploadImage(MultipartFile file, ImageResponse image) {
-        try {
-            minioClient.putObject(
-                    PutObjectArgs.builder()
-                            .bucket(bucketName)
-                            .object(image.getStoredFileName())
-                            .stream(file.getInputStream(), file.getSize(), -1)
-                            .contentType(file.getContentType())
-                            .build()
-            );
-        } catch (IOException e){
-            log.error("IOException 발생: 이미지 입력 스트림을 읽을 수 없습니다.", e);
-        }
-        catch (Exception e) {
-            log.error("Exception 발생: ", e);
-        }
+        CompletableFuture.runAsync(() -> {
+            try {
+                minioClient.putObject(
+                        PutObjectArgs.builder()
+                                .bucket(bucketName)
+                                .object(image.getStoredFileName())
+                                .stream(file.getInputStream(), file.getSize(), -1)
+                                .contentType(file.getContentType())
+                                .build()
+                );
+                kafkaTemplate.send("image-upload-topic", image.getStoredFileName());
+            } catch (Exception e) {
+                log.error("이미지 업로드 중 오류 발생: ", e);
+            }
+        });
+    }
 
-        kafkaTemplate.send("image-upload-topic", image.getStoredFileName());
+    @SneakyThrows
+    public ResponseEntity<byte[]> getImage(String cdnUrl) {
+        byte[] imageBytes = minioClient.getObject(
+                GetObjectArgs.builder()
+                        .bucket(bucketName)
+                        .object("")
+                        .build()).readAllBytes();
+
+        // 응답 헤더 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.parseMediaType("image/jpeg"));
+
+        return new ResponseEntity<>(imageBytes, headers, HttpStatus.OK);
+    }
+
+    @SneakyThrows
+    public ResponseEntity<byte[]> downloadImage(String cdnUrl){
+        byte[] imageBytes = minioClient.getObject(
+                GetObjectArgs.builder()
+                        .bucket(bucketName)
+                        .object("")
+                        .build()).readAllBytes();
+
+        // 응답 헤더 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.parseMediaType("image/jpeg"));
+        headers.setContentDispositionFormData("attachment", "test.jpeg");
+
+        return new ResponseEntity<>(imageBytes, headers, HttpStatus.OK);
     }
 }

--- a/upload/src/main/java/image/module/upload/application/UploadService.java
+++ b/upload/src/main/java/image/module/upload/application/UploadService.java
@@ -83,7 +83,7 @@ public class UploadService {
                 uploadImage(new ByteArrayInputStream(fileBytes), file.getContentType(), imageResponse);
 
                 return imageResponse.getOriginalFileUUID().toString();
-            } catch (Exception e) {
+            } catch (Exception e) {//db 데이터 삭제?
                 log.error("이미지 메타데이터 저장 중 오류 발생: ", e);
                 throw new RuntimeException(e);
             }
@@ -91,8 +91,8 @@ public class UploadService {
     }
 
     //이미지 업로드
+    @SneakyThrows
     public void uploadImage(InputStream fileInputStream, String contentType, ImageResponse image) {
-        try {
             minioClient.putObject(
                     PutObjectArgs.builder()
                             .bucket(bucketName)
@@ -102,10 +102,6 @@ public class UploadService {
                             .build()
             );
             kafkaTemplate.send("image-upload-topic", image.getStoredFileName());
-        } catch (Exception e) {
-            log.error("이미지 업로드 중 오류 발생: ", e);
-        }
-
     }
 
 

--- a/upload/src/main/java/image/module/upload/application/UploadService.java
+++ b/upload/src/main/java/image/module/upload/application/UploadService.java
@@ -44,8 +44,11 @@ public class UploadService {
     public CompletableFuture<Void> saveImageMetadata(MultipartFile file) {
         return CompletableFuture.runAsync(() -> {
             try {
-                // 파일 데이터를 미리 메모리에 저장
+                // 파일 데이터를 메모리에 저장
                 byte[] fileBytes = file.getBytes();
+
+                // 파일 데이터를 기반으로 InputStream 생성
+                ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(fileBytes);
 
                 // 업로드 파일명을 불러옴
                 String originalName = file.getOriginalFilename();
@@ -61,7 +64,7 @@ public class UploadService {
                         .orElseThrow(() -> new Exception("지원하지 않는 확장자 입니다."));
 
                 // 이미지 크기 확인
-                BufferedImage bufferedImage = ImageIO.read(new ByteArrayInputStream(fileBytes));
+                BufferedImage bufferedImage = ImageIO.read(byteArrayInputStream);
                 int imageWidth = bufferedImage.getWidth();
                 int imageHeight = bufferedImage.getHeight();
 
@@ -76,7 +79,7 @@ public class UploadService {
                 // 메타데이터 저장
                 ImageResponse imageResponse = dataService.uploadImage(imageRequest);
 
-                // minio 이미지 업로드
+                // 새롭게 InputStream을 생성하여 minio에 이미지 업로드
                 uploadImage(new ByteArrayInputStream(fileBytes), file.getContentType(), imageResponse);
 
             } catch (Exception e) {

--- a/upload/src/main/java/image/module/upload/application/UploadService.java
+++ b/upload/src/main/java/image/module/upload/application/UploadService.java
@@ -90,34 +90,34 @@ public class UploadService {
         });
     }
 
-    @SneakyThrows
-    public ResponseEntity<byte[]> getImage(String cdnUrl) {
-        byte[] imageBytes = minioClient.getObject(
-                GetObjectArgs.builder()
-                        .bucket(bucketName)
-                        .object("")
-                        .build()).readAllBytes();
-
-        // 응답 헤더 설정
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.parseMediaType("image/jpeg"));
-
-        return new ResponseEntity<>(imageBytes, headers, HttpStatus.OK);
-    }
-
-    @SneakyThrows
-    public ResponseEntity<byte[]> downloadImage(String cdnUrl){
-        byte[] imageBytes = minioClient.getObject(
-                GetObjectArgs.builder()
-                        .bucket(bucketName)
-                        .object("")
-                        .build()).readAllBytes();
-
-        // 응답 헤더 설정
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.parseMediaType("image/jpeg"));
-        headers.setContentDispositionFormData("attachment", "test.jpeg");
-
-        return new ResponseEntity<>(imageBytes, headers, HttpStatus.OK);
-    }
+//    @SneakyThrows
+//    public ResponseEntity<byte[]> getImage(String cdnUrl) {
+//        byte[] imageBytes = minioClient.getObject(
+//                GetObjectArgs.builder()
+//                        .bucket(bucketName)
+//                        .object("")
+//                        .build()).readAllBytes();
+//
+//        // 응답 헤더 설정
+//        HttpHeaders headers = new HttpHeaders();
+//        headers.setContentType(MediaType.parseMediaType("image/jpeg"));
+//
+//        return new ResponseEntity<>(imageBytes, headers, HttpStatus.OK);
+//    }
+//
+//    @SneakyThrows
+//    public ResponseEntity<byte[]> downloadImage(String cdnUrl){
+//        byte[] imageBytes = minioClient.getObject(
+//                GetObjectArgs.builder()
+//                        .bucket(bucketName)
+//                        .object("")
+//                        .build()).readAllBytes();
+//
+//        // 응답 헤더 설정
+//        HttpHeaders headers = new HttpHeaders();
+//        headers.setContentType(MediaType.parseMediaType("image/jpeg"));
+//        headers.setContentDispositionFormData("attachment", "test.jpeg");
+//
+//        return new ResponseEntity<>(imageBytes, headers, HttpStatus.OK);
+//    }
 }

--- a/upload/src/main/java/image/module/upload/presentation/UploadController.java
+++ b/upload/src/main/java/image/module/upload/presentation/UploadController.java
@@ -2,9 +2,15 @@ package image.module.upload.presentation;
 
 import image.module.upload.application.UploadService;
 import image.module.upload.application.ImageResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -22,14 +28,28 @@ public class UploadController {
     public ResponseEntity<?> uploadImage(@RequestParam("file") MultipartFile file) {
         try {
             // 1. DB에 파일 메타데이터 저장 및 응답
-            ImageResponse imageResponse = uploadService.saveImageMetadata(file);
-            // 2. 비동기적으로 MinIO에 파일 저장
-            uploadService.uploadImage(file, imageResponse);
+            CompletableFuture<ImageResponse> imageResponseFuture = uploadService.saveImageMetadata(file);
 
-            return ResponseEntity.ok(imageResponse.getOriginalFileUUID());
+            // 2. 비동기적으로 MinIO에 파일 저장
+            imageResponseFuture.thenAccept(imageResponse ->
+                    uploadService.uploadImage(file, imageResponse)
+            );
+
+            // 즉시 응답 반환
+            return ResponseEntity.ok("이미지 업로드가 시작되었습니다.");
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                     .body("Upload failed: " + e.getMessage());
         }
+    }
+
+    @GetMapping("/test")
+    public ResponseEntity<byte[]> getImage(HttpServletRequest request) {
+        return uploadService.getImage(request.getRequestURL().toString());
+    }
+
+    @GetMapping("/downloadTest")
+    public ResponseEntity<byte[]> downloadImage(HttpServletRequest request) {
+        return uploadService.downloadImage(request.getRequestURL().toString());
     }
 }

--- a/upload/src/main/java/image/module/upload/presentation/UploadController.java
+++ b/upload/src/main/java/image/module/upload/presentation/UploadController.java
@@ -43,13 +43,13 @@ public class UploadController {
         }
     }
 
-    @GetMapping("/test")
-    public ResponseEntity<byte[]> getImage(HttpServletRequest request) {
-        return uploadService.getImage(request.getRequestURL().toString());
-    }
-
-    @GetMapping("/downloadTest")
-    public ResponseEntity<byte[]> downloadImage(HttpServletRequest request) {
-        return uploadService.downloadImage(request.getRequestURL().toString());
-    }
+//    @GetMapping("/test")
+//    public ResponseEntity<byte[]> getImage(HttpServletRequest request) {
+//        return uploadService.getImage(request.getRequestURL().toString());
+//    }
+//
+//    @GetMapping("/downloadTest")
+//    public ResponseEntity<byte[]> downloadImage(HttpServletRequest request) {
+//        return uploadService.downloadImage(request.getRequestURL().toString());
+//    }
 }

--- a/upload/src/main/java/image/module/upload/presentation/UploadController.java
+++ b/upload/src/main/java/image/module/upload/presentation/UploadController.java
@@ -3,11 +3,13 @@ package image.module.upload.presentation;
 import image.module.upload.application.UploadService;
 import image.module.upload.application.ImageResponse;
 import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,7 +18,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/image/upload")
@@ -27,13 +31,7 @@ public class UploadController {
     @PostMapping
     public ResponseEntity<?> uploadImage(@RequestParam("file") MultipartFile file) {
         try {
-            // 1. DB에 파일 메타데이터 저장 및 응답
-            CompletableFuture<ImageResponse> imageResponseFuture = uploadService.saveImageMetadata(file);
-
-            // 2. 비동기적으로 MinIO에 파일 저장
-            imageResponseFuture.thenAccept(imageResponse ->
-                    uploadService.uploadImage(file, imageResponse)
-            );
+            uploadService.saveImageMetadata(file);
 
             // 즉시 응답 반환
             return ResponseEntity.ok("이미지 업로드가 시작되었습니다.");

--- a/upload/src/main/java/image/module/upload/presentation/UploadController.java
+++ b/upload/src/main/java/image/module/upload/presentation/UploadController.java
@@ -38,7 +38,7 @@ public class UploadController {
                     .thenApply(result -> {
                         try {
                             // 반환된 결과(result)를 클라이언트로 전송
-                            emitter.send(SseEmitter.event().name("PROGRESS").data("이미지 업로드 완료: " + result));
+                            emitter.send(SseEmitter.event().name("SUCCESS").data("이미지 업로드 완료: " + result));
                             // 작업 완료 후 emitter 종료
                             emitter.complete();
                         } catch (IOException e) {
@@ -58,7 +58,6 @@ public class UploadController {
                     });
 
         } catch (Exception e) {
-            // 즉시 오류 발생 시 처리
             emitter.send(SseEmitter.event().name("ERROR").data("업로드 실패..."));
             emitter.completeWithError(e);
         }

--- a/upload/src/main/resources/application.yml
+++ b/upload/src/main/resources/application.yml
@@ -14,10 +14,10 @@ spring:
 server:
   port: 19092
 
-#eureka:
-#  client:
-#    service-url:
-#      defaultZone: http://localhost:19090/eureka/
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:19090/eureka/
 
 minio:
   url: http://localhost:9000


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #40

## 📝작업 내용

> Server-sent-event 통신 기술을 사용하여 업로드 실패 및 성공 응답을 클라이언트에게 알려줍니다.
> NoSuchFileException 오류 해결
![image (10)](https://github.com/user-attachments/assets/6309e745-dc9e-4958-848b-af1bbf9da4fe)
![image (11)](https://github.com/user-attachments/assets/06147a04-821f-4b76-9e60-a4a32491000b)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 이미지 메타데이터 비동기 처리 기능 추가.
	- 서버 전송 이벤트(SSE)를 통한 실시간 업로드 상태 통신 기능 추가.
	- Eureka 서비스 발견 기능 활성화.

- **버그 수정**
	- 이미지 업로드 메서드의 오류 처리 간소화.

- **문서화**
	- `application.yml` 파일의 Eureka 및 MinIO 설정 수정.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->