### PR TITLE
Refactor : #48- DB의존성 제거, FeignClient 이름 수정

### DIFF
--- a/internal/build.gradle
+++ b/internal/build.gradle
@@ -34,8 +34,10 @@ dependencies {
 	// kafka
 	implementation 'org.springframework.kafka:spring-kafka'
 
+	// EurekaClient
+	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+
 	// Thumbnailator (이미지 리사이징)
-	// implementation 'net.coobird:thumbnailator:0.4.14'
 	implementation group: 'net.coobird', name: 'thumbnailator', version: '0.4.20'
 
 	//minio
@@ -49,12 +51,7 @@ dependencies {
 	// Apache Commons IO / ImageService에서 FileUtils 사용 시 필요 (파일 복사)
 	implementation 'commons-io:commons-io:2.11.0'
 
-	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
-
-	runtimeOnly 'org.postgresql:postgresql'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	//implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/internal/src/main/java/image/module/internal/DataClient.java
+++ b/internal/src/main/java/image/module/internal/DataClient.java
@@ -6,7 +6,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
-@FeignClient(name = "data-service")
+@FeignClient(name = "data")
 public interface DataClient {
 
   @PostMapping("/image/upload/resize")

--- a/internal/src/main/resources/application-dev.yml
+++ b/internal/src/main/resources/application-dev.yml
@@ -1,22 +1,6 @@
 spring:
   application:
     name: internal
-  datasource:
-    url: jdbc:postgresql://localhost:5432/server_data
-    username: server_data_db
-    password: server_data_db
-    driver-class-name: org.postgresql.Driver
-  jpa:
-    hibernate:
-      ddl-auto: update
-    show-sql: true
-    properties:
-      hibernate:
-        format_sql: true
-        show_sql: true
-        use_sql_comments: true
-        highlight_sql: true
-    database-platform: org.hibernate.dialect.PostgreSQLDialect
   kafka:
     bootstrap-servers: localhost:9092
     producer:
@@ -46,9 +30,6 @@ minio:
   buckets:
     downloadBucket: mybucket
     uploadBucket: update-bucket
-
-data-server:
-  url: localhost:19095
 
 cdn-server:
   url: http://localhost:19096/cdn

--- a/internal/src/main/resources/application.yml
+++ b/internal/src/main/resources/application.yml
@@ -1,3 +1,3 @@
 spring:
   profiles:
-    active: prod
+    active: dev


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #48

## 📝작업 내용

> build.gradle에 DB 관련 의존성 제거
> FeignClient 이름 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
	- 중복된 Eureka 클라이언트 의존성 제거 및 정리.
  
- **구성 변경**
	- 데이터 소스, JPA 및 데이터 서버 관련 설정 삭제.
  
- **기능 개선**
	- Feign 클라이언트 이름 변경으로 서비스 통신 식별 개선.
  
- **환경 설정 변경**
	- 활성 Spring 프로필을 `prod`에서 `dev`로 변경.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->