### PR TITLE
Feat: #50 CDN 이미지 반환 기능 구현

### DIFF
--- a/cdn/src/main/java/image/module/cdn/client/UrlServiceClient.java
+++ b/cdn/src/main/java/image/module/cdn/client/UrlServiceClient.java
@@ -2,6 +2,7 @@ package image.module.cdn.client;
 
 import image.module.cdn.dto.ImageDto;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -10,4 +11,7 @@ public interface UrlServiceClient {
 
     @GetMapping(value = "/fetch/image")
     ImageDto fetchImage(@RequestParam("cdnUrl") String cdnUrl);
+
+    @GetMapping(value = "/fetch/image/byte")
+    ResponseEntity<byte[]> fetchImageByte(@RequestParam("cdnUrl") String cdnUrl);
 }

--- a/cdn/src/main/java/image/module/cdn/dto/ImageDto.java
+++ b/cdn/src/main/java/image/module/cdn/dto/ImageDto.java
@@ -7,6 +7,6 @@ import lombok.Setter;
 @Setter
 public class ImageDto {
 
-    private byte[] imageStream;
+    // private byte[] imageStream;
     private String fileName;
 }

--- a/cdn/src/main/java/image/module/cdn/service/CdnService.java
+++ b/cdn/src/main/java/image/module/cdn/service/CdnService.java
@@ -9,7 +9,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -109,13 +108,15 @@ public class CdnService {
         ImageDto imageDto = urlServiceClient.fetchImage(URLEncoder.encode(cdnUrl, StandardCharsets.UTF_8));
         log.info("이미지 이름 " + imageDto.getFileName());
 
-        log.info("이미지 값 " + Arrays.toString(imageDto.getImageStream()));
-
         // cdn에 저장할 이미지 이름 생성
         String cdnImageName = cdnUrl.replace(getPartCdnUrl(), "");
         String saveFileName = imageDto.getFileName() + "_" + cdnImageName;
 
-        String fileLocation = saveImageInCdn(imageDto.getImageStream(), saveFileName);
+        // String fileLocation = saveImageInCdn(imageDto.getImageStream(), saveFileName);
+
+        byte[] imageByte = urlServiceClient.fetchImageByte(URLEncoder.encode(cdnUrl, StandardCharsets.UTF_8)).getBody();
+
+        String fileLocation = saveImageInCdn(imageByte, saveFileName);
 
         // TODO: FeignClient에서 추후 caching time 받아서 처리하도록 수정
         redisService.setValue(cdnUrl, fileLocation, 1);

--- a/cdn/src/main/java/image/module/cdn/service/RedisService.java
+++ b/cdn/src/main/java/image/module/cdn/service/RedisService.java
@@ -26,7 +26,9 @@ public class RedisService {
         String value = redisTemplate.opsForValue().get(key);
         if (value != null) {
             String initialTTL = redisTemplate.opsForValue().get(key + ":ttl");
-            redisTemplate.expire(key, Integer.parseInt(initialTTL), TimeUnit.MINUTES);
+            if (initialTTL != null) {
+                redisTemplate.expire(key, Integer.parseInt(initialTTL), TimeUnit.MINUTES);
+            }
         }
         return value;
     }

--- a/url/src/main/java/image/module/url/controller/UrlController.java
+++ b/url/src/main/java/image/module/url/controller/UrlController.java
@@ -4,19 +4,16 @@ import image.module.url.client.data.DataService;
 import image.module.url.client.data.ImageResponse;
 import image.module.url.dto.ImageDto;
 import image.module.url.service.UrlService;
-import io.minio.GetObjectArgs;
-import io.minio.MinioClient;
-import lombok.extern.log4j.Log4j2;
-import org.springframework.beans.factory.annotation.Value;
-
-
-import org.springframework.web.bind.annotation.*;
-
-import javax.imageio.ImageIO;
-import java.awt.image.BufferedImage;
-import java.io.*;
-
 import java.util.UUID;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @Log4j2
 @RestController
@@ -48,9 +45,6 @@ public class UrlController {
         String cdnUrl = imageResponse.getCdnUrl();
         log.info("CDN URL: {}", cdnUrl);
 
-
-
-
         return cdnUrl;
     }
 
@@ -59,15 +53,18 @@ public class UrlController {
     // 이미지 데이터가 JSON 응답에 포함되어 있기 때문에 CDN에서 캐싱하거나 브라우저에서 이미지로 바로 사용하기 어려움
     @GetMapping("/image")
     public ImageDto fetchImage(@RequestParam("cdnUrl") String cdnUrl) {
-       return urlService.fatchImage(cdnUrl);
+        return urlService.fetchImage(cdnUrl);
     }
 
-
-
-
-
-
-
+    // 이미지 바이트 배열로 반환하는 FeignClient용 api
+    @GetMapping("/image/byte")
+    public ResponseEntity<byte[]> fetchImageByte(@RequestParam("cdnUrl") String cdnUrl) {
+        byte[] imageBytes = urlService.fetchImageByte(cdnUrl);
+        // 적절한 MIME 타입으로 응답을 설정 (예: 이미지의 경우)
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_OCTET_STREAM); // 또는 MediaType.IMAGE_PNG 등
+        return new ResponseEntity<>(imageBytes, headers, HttpStatus.OK);
+    }
 }
 
 

--- a/url/src/main/java/image/module/url/dto/ImageDto.java
+++ b/url/src/main/java/image/module/url/dto/ImageDto.java
@@ -11,11 +11,7 @@ public class ImageDto {
     @JsonProperty("fileName")
     private String fileName;
 
-    @JsonProperty("imageData")
-    private byte[] imageData; // 이미지 데이터
-
-    public ImageDto(String fileName, byte[] imageBytes) {
+    public ImageDto(String fileName) {
         this.fileName = fileName;
-        this.imageData = imageBytes;
     }
 }

--- a/url/src/main/java/image/module/url/service/UrlService.java
+++ b/url/src/main/java/image/module/url/service/UrlService.java
@@ -5,14 +5,15 @@ import image.module.url.client.data.ImageResponse;
 import image.module.url.dto.ImageDto;
 import io.minio.GetObjectArgs;
 import io.minio.MinioClient;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import javax.imageio.ImageIO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-
-import javax.imageio.ImageIO;
-import java.awt.image.BufferedImage;
-import java.io.*;
 
 @Log4j2
 @Service
@@ -28,7 +29,26 @@ public class UrlService {
     @Value("${minio.buckets.downloadBucket}")
     private String downloadBucket;
 
-    public ImageDto fatchImage(String cdnUrl) {
+    public ImageDto fetchImage(String cdnUrl) {
+        // CDN URL을 통해 데이터베이스에서 파일 이름 조회
+        log.info("받은 CDN URL: {}", cdnUrl);
+        ImageResponse imageResponse = dataService.getCDNImageName(cdnUrl);
+
+        // imageResponse가 null인지 확인
+        if (imageResponse == null) {
+            throw new RuntimeException("제공된 CDN URL에 대한 이미지를 찾을 수 없습니다.");
+        }
+
+        String fileName = imageResponse.getStoredFileName();
+        String fileType = imageResponse.getFileType();
+        log.info("저장된 파일명: {}", fileName);
+        log.info("파일 타입: {}", fileType);
+
+        // ImageDto 생성 및 반환
+        return new ImageDto(fileName);
+    }
+
+    public byte[] fetchImageByte(String cdnUrl) {
 
         try {
             // CDN URL을 통해 데이터베이스에서 파일 이름 조회
@@ -43,7 +63,7 @@ public class UrlService {
             String fileName = imageResponse.getStoredFileName();
             String fileType = imageResponse.getFileType();
             log.info("저장된 파일명: {}", fileName);
-            log.info("파일 타입: {}", imageResponse.getFileType());
+            log.info("파일 타입: {}", fileType);
 
             String bucketToUse = fileType.equalsIgnoreCase("webp") ? uploadBucket : downloadBucket;
 
@@ -85,7 +105,7 @@ public class UrlService {
             log.info("이미지 바이트 길이: {}", imageBytes.length);
 
             // ImageDto 생성 및 반환
-            return new ImageDto(fileName, imageBytes);
+            return imageBytes;
         } catch (IOException e) {
             log.error("입출력 오류 발생: {}", e.getMessage());
             throw new RuntimeException("이미지 처리 중 오류 발생: " + e.getMessage());


### PR DESCRIPTION
feign client 메서드 2개로 분리

## #️⃣연관된 이슈

> close #50 

## 📝작업 내용

> byte[] 반환 메서드와 이미지 정보 반환 메서드 분리

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 이미지 데이터를 바이트 배열로 가져오는 새로운 API 엔드포인트 추가.
- **버그 수정**
	- `fatchImage` 메서드의 이름을 `fetchImage`로 수정.
- **구조 개선**
	- `ImageDto` 클래스에서 불필요한 필드 제거 및 생성자 간소화.
	- 이미지 가져오기 프로세스를 간소화하여 중간 객체 제거.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->