### PR TITLE
Feature/#60 upload - size,cahingTime

### DIFF
--- a/data/src/main/java/image/module/data/application/ImageResponse.java
+++ b/data/src/main/java/image/module/data/application/ImageResponse.java
@@ -21,7 +21,7 @@ public class ImageResponse {
     private String cdnUrl;
     private String fileType;
     private Integer size;
-    private Integer cashingTime;
+    private Integer cachingTime;
     private UUID originalFileUUID;
 
     public static ImageResponse fromEntity(Image image){
@@ -32,7 +32,7 @@ public class ImageResponse {
                 .cdnUrl(image.getCdnUrl())
                 .fileType(image.getFileType())
                 .size(image.getSize())
-                .cashingTime(image.getCashingTime())
+                .cachingTime(image.getCachingTime())
                 .originalFileUUID(image.getOriginalFileUUID())
                 .build();
     }

--- a/data/src/main/java/image/module/data/application/ImageResponse.java
+++ b/data/src/main/java/image/module/data/application/ImageResponse.java
@@ -20,8 +20,7 @@ public class ImageResponse {
     private String storedFileName;
     private String cdnUrl;
     private String fileType;
-    private Integer width;
-    private Integer height;
+    private Integer size;
     private UUID originalFileUUID;
 
     public static ImageResponse fromEntity(Image image){
@@ -31,8 +30,7 @@ public class ImageResponse {
                 .storedFileName(image.getStoredFileName())
                 .cdnUrl(image.getCdnUrl())
                 .fileType(image.getFileType())
-                .width(image.getWidth())
-                .height(image.getHeight())
+                .size(image.getSize())
                 .originalFileUUID(image.getOriginalFileUUID())
                 .build();
     }

--- a/data/src/main/java/image/module/data/application/ImageResponse.java
+++ b/data/src/main/java/image/module/data/application/ImageResponse.java
@@ -21,6 +21,7 @@ public class ImageResponse {
     private String cdnUrl;
     private String fileType;
     private Integer size;
+    private Integer cashingTime;
     private UUID originalFileUUID;
 
     public static ImageResponse fromEntity(Image image){
@@ -31,6 +32,7 @@ public class ImageResponse {
                 .cdnUrl(image.getCdnUrl())
                 .fileType(image.getFileType())
                 .size(image.getSize())
+                .cashingTime(image.getCashingTime())
                 .originalFileUUID(image.getOriginalFileUUID())
                 .build();
     }

--- a/data/src/main/java/image/module/data/application/ImageService.java
+++ b/data/src/main/java/image/module/data/application/ImageService.java
@@ -16,7 +16,7 @@ public class ImageService {
     private final ImageRepository imageRepository;
 
     @Transactional
-    public ImageResponse createImage(ImageRequest request){
+    public ImageResponse saveImage(ImageRequest request){
         Image image = Image.create(request);
         imageRepository.save(image);
         image.assignOriginalFileUUID();

--- a/data/src/main/java/image/module/data/domain/Image.java
+++ b/data/src/main/java/image/module/data/domain/Image.java
@@ -42,10 +42,7 @@ public class Image extends BaseEntity {
     private String fileType;
 
     @Column(nullable = false)
-    private Integer width;
-
-    @Column(nullable = false)
-    private Integer height;
+    private Integer size;
 
     @Column(name = "original_file_uuid")
     private UUID originalFileUUID;
@@ -56,8 +53,7 @@ public class Image extends BaseEntity {
                 .storedFileName(request.getStoredFileName())
                 .cdnUrl(request.getCdnUrl())
                 .fileType(request.getFileType())
-                .width(request.getWidth())
-                .height(request.getHeight())
+                .size(request.getSize())
                 .build();
     }
 
@@ -67,8 +63,7 @@ public class Image extends BaseEntity {
                 .storedFileName(imageRequest.getStoredFileName())
                 .cdnUrl(imageRequest.getCdnUrl())
                 .fileType(imageRequest.getFileType())
-                .width(imageRequest.getWidth())
-                .height(imageRequest.getHeight())
+                .size(imageRequest.getSize())
                 .originalFileUUID(image.getId())
                 .build();
     }

--- a/data/src/main/java/image/module/data/domain/Image.java
+++ b/data/src/main/java/image/module/data/domain/Image.java
@@ -44,7 +44,7 @@ public class Image extends BaseEntity {
     private Integer size;
 
     @Column(nullable = false)
-    private Integer cashingTime;
+    private Integer cachingTime;
 
     @Column(name = "original_file_uuid")
     private UUID originalFileUUID;
@@ -55,7 +55,7 @@ public class Image extends BaseEntity {
                 .storedFileName(request.getStoredFileName())
                 .fileType(request.getFileType())
                 .size(request.getSize())
-                .cashingTime(request.getCashingTime())
+                .cachingTime(request.getCachingTime())
                 .build();
     }
 

--- a/data/src/main/java/image/module/data/domain/Image.java
+++ b/data/src/main/java/image/module/data/domain/Image.java
@@ -44,6 +44,9 @@ public class Image extends BaseEntity {
     @Column(nullable = false)
     private Integer size;
 
+    @Column(nullable = false)
+    private Integer cashingTime;
+
     @Column(name = "original_file_uuid")
     private UUID originalFileUUID;
 
@@ -54,6 +57,7 @@ public class Image extends BaseEntity {
                 .cdnUrl(request.getCdnUrl())
                 .fileType(request.getFileType())
                 .size(request.getSize())
+                .cashingTime(request.getCashingTime())
                 .build();
     }
 

--- a/data/src/main/java/image/module/data/domain/Image.java
+++ b/data/src/main/java/image/module/data/domain/Image.java
@@ -35,7 +35,6 @@ public class Image extends BaseEntity {
     @Column(nullable = false)
     private String storedFileName;
 
-    @Column(nullable = false)
     private String cdnUrl;
 
     @Column(nullable = false)
@@ -54,7 +53,6 @@ public class Image extends BaseEntity {
         return Image.builder()
                 .originalFileName(request.getOriginalFileName())
                 .storedFileName(request.getStoredFileName())
-                .cdnUrl(request.getCdnUrl())
                 .fileType(request.getFileType())
                 .size(request.getSize())
                 .cashingTime(request.getCashingTime())

--- a/data/src/main/java/image/module/data/presentation/ImageController.java
+++ b/data/src/main/java/image/module/data/presentation/ImageController.java
@@ -16,7 +16,7 @@ public class ImageController {
 
     @PostMapping("/image/upload")
     public ImageResponse uploadImage(@RequestBody ImageRequest imageRequest){
-        return imageService.createImage(imageRequest);
+        return imageService.saveImage(imageRequest);
     }
 
     //fetch -> 객체 조회

--- a/data/src/main/java/image/module/data/presentation/ImageRequest.java
+++ b/data/src/main/java/image/module/data/presentation/ImageRequest.java
@@ -24,6 +24,6 @@ public class ImageRequest {
     private String cdnUrl;
     private String fileType;
     private Integer size;
-    private Integer cashingTime;
+    private Integer cachingTime;
     private UUID originalFileUUID;
 }

--- a/data/src/main/java/image/module/data/presentation/ImageRequest.java
+++ b/data/src/main/java/image/module/data/presentation/ImageRequest.java
@@ -24,5 +24,6 @@ public class ImageRequest {
     private String cdnUrl;
     private String fileType;
     private Integer size;
+    private Integer cashingTime;
     private UUID originalFileUUID;
 }

--- a/data/src/main/java/image/module/data/presentation/ImageRequest.java
+++ b/data/src/main/java/image/module/data/presentation/ImageRequest.java
@@ -23,7 +23,6 @@ public class ImageRequest {
     private String storedFileName;
     private String cdnUrl;
     private String fileType;
-    private Integer width;
-    private Integer height;
+    private Integer size;
     private UUID originalFileUUID;
 }

--- a/upload/src/main/java/image/module/upload/application/ImageRequest.java
+++ b/upload/src/main/java/image/module/upload/application/ImageRequest.java
@@ -20,12 +20,12 @@ public class ImageRequest {
     private String storedFileName;
     private String fileType;
     private Integer size;
-    private Integer cashingTime;
+    private Integer cachingTime;
 
     public static ImageRequest create(String originalName,
                                       String extension,
                                       int size,
-                                      int cashingTime) {
+                                      int cachingTime) {
         // 1. UUID 생성
         String uuid = UUID.randomUUID().toString();
 
@@ -40,7 +40,7 @@ public class ImageRequest {
                 .storedFileName(storedFileName)
                 .fileType(extension)
                 .size(size)
-                .cashingTime(cashingTime)
+                .cachingTime(cachingTime)
                 .build();
     }
 }

--- a/upload/src/main/java/image/module/upload/application/ImageRequest.java
+++ b/upload/src/main/java/image/module/upload/application/ImageRequest.java
@@ -18,14 +18,12 @@ public class ImageRequest {
     private UUID id;
     private String originalFileName;
     private String storedFileName;
-    private String cdnUrl;
     private String fileType;
     private Integer size;
     private Integer cashingTime;
 
     public static ImageRequest create(String originalName,
                                       String extension,
-                                      String cdnBaseUrl,
                                       int size,
                                       int cashingTime) {
         // 1. UUID 생성
@@ -37,13 +35,9 @@ public class ImageRequest {
         // 3. 저장할 파일 이름 생성 (이미지 이름 치환하기)
         String storedFileName = uuid + "_" + formattedTime;
 
-        // 5. cdn url 생성
-        String cdnUrl = cdnBaseUrl + "/" + UUID.randomUUID() + "." + extension;
-
         return ImageRequest.builder()
                 .originalFileName(originalName)
                 .storedFileName(storedFileName)
-                .cdnUrl(cdnUrl)
                 .fileType(extension)
                 .size(size)
                 .cashingTime(cashingTime)

--- a/upload/src/main/java/image/module/upload/application/ImageRequest.java
+++ b/upload/src/main/java/image/module/upload/application/ImageRequest.java
@@ -20,14 +20,12 @@ public class ImageRequest {
     private String storedFileName;
     private String cdnUrl;
     private String fileType;
-    private Integer width;
-    private Integer height;
+    private Integer size;
 
     public static ImageRequest create(String originalName,
                                       String extension,
                                       String cdnBaseUrl,
-                                      int imageWidth,
-                                      int imageHeight) {
+                                      int size) {
         // 1. UUID 생성
         String uuid = UUID.randomUUID().toString();
 
@@ -45,8 +43,7 @@ public class ImageRequest {
                 .storedFileName(storedFileName)
                 .cdnUrl(cdnUrl)
                 .fileType(extension)
-                .width(imageWidth)
-                .height(imageHeight)
+                .size(size)
                 .build();
     }
 }

--- a/upload/src/main/java/image/module/upload/application/ImageRequest.java
+++ b/upload/src/main/java/image/module/upload/application/ImageRequest.java
@@ -21,11 +21,13 @@ public class ImageRequest {
     private String cdnUrl;
     private String fileType;
     private Integer size;
+    private Integer cashingTime;
 
     public static ImageRequest create(String originalName,
                                       String extension,
                                       String cdnBaseUrl,
-                                      int size) {
+                                      int size,
+                                      int cashingTime) {
         // 1. UUID 생성
         String uuid = UUID.randomUUID().toString();
 
@@ -44,6 +46,7 @@ public class ImageRequest {
                 .cdnUrl(cdnUrl)
                 .fileType(extension)
                 .size(size)
+                .cashingTime(cashingTime)
                 .build();
     }
 }

--- a/upload/src/main/java/image/module/upload/application/ImageResponse.java
+++ b/upload/src/main/java/image/module/upload/application/ImageResponse.java
@@ -16,9 +16,7 @@ public class ImageResponse {
     private UUID id;
     private String originalFileName;
     private String storedFileName;
-    private String cdnUrl;
     private String fileType;
-    private Integer width;
-    private Integer height;
+    private Integer size;
     private UUID originalFileUUID;
 }

--- a/upload/src/main/java/image/module/upload/application/ImageUploadMessage.java
+++ b/upload/src/main/java/image/module/upload/application/ImageUploadMessage.java
@@ -1,0 +1,24 @@
+package image.module.upload.application;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ImageUploadMessage {
+    private String storedFileName;
+    private int imageSize;
+
+    public static ImageUploadMessage createMessage(String storedFileName, int imageSize){
+        return ImageUploadMessage.builder()
+                .storedFileName(storedFileName)
+                .imageSize(imageSize)
+                .build();
+    }
+}

--- a/upload/src/main/java/image/module/upload/application/ImageUploadMessage.java
+++ b/upload/src/main/java/image/module/upload/application/ImageUploadMessage.java
@@ -13,12 +13,12 @@ import lombok.Setter;
 @Builder
 public class ImageUploadMessage {
     private String storedFileName;
-    private int imageSize;
+    private Integer requestSize;
 
-    public static ImageUploadMessage createMessage(String storedFileName, int imageSize){
+    public static ImageUploadMessage createMessage(String storedFileName, int requestSize){
         return ImageUploadMessage.builder()
                 .storedFileName(storedFileName)
-                .imageSize(imageSize)
+                .requestSize(requestSize)
                 .build();
     }
 }

--- a/upload/src/main/java/image/module/upload/application/UploadService.java
+++ b/upload/src/main/java/image/module/upload/application/UploadService.java
@@ -34,7 +34,7 @@ public class UploadService {
     private String cdnBaseUrl;
 
     //이미지 데이터 db 저장
-    public CompletableFuture<String> saveImageMetadata(MultipartFile file, int size) {
+    public CompletableFuture<String> saveImageMetadata(MultipartFile file, int size, int cashingTime) {
         return CompletableFuture.supplyAsync(() -> {
             try {
                 // 업로드 파일명을 불러옴
@@ -60,7 +60,8 @@ public class UploadService {
                         originalName,
                         extension.getKey(),
                         cdnBaseUrl,
-                        imageSize
+                        imageSize,
+                        cashingTime
                 );
 
                 // 메타데이터 저장

--- a/upload/src/main/java/image/module/upload/application/UploadService.java
+++ b/upload/src/main/java/image/module/upload/application/UploadService.java
@@ -30,9 +30,6 @@ public class UploadService {
     @Value("${minio.bucket}")
     private String bucketName;
 
-    @Value("${cdn-server.url}")
-    private String cdnBaseUrl;
-
     //이미지 데이터 db 저장
     public CompletableFuture<String> saveImageMetadata(MultipartFile file, int size, int cashingTime) {
         return CompletableFuture.supplyAsync(() -> {
@@ -59,7 +56,6 @@ public class UploadService {
                 ImageRequest imageRequest = ImageRequest.create(
                         originalName,
                         extension.getKey(),
-                        cdnBaseUrl,
                         imageSize,
                         cashingTime
                 );

--- a/upload/src/main/java/image/module/upload/presentation/UploadController.java
+++ b/upload/src/main/java/image/module/upload/presentation/UploadController.java
@@ -31,12 +31,12 @@ public class UploadController {
     @PostMapping
     public SseEmitter uploadImage(@RequestParam("file") MultipartFile file,
                                   @RequestParam(value = "size") int size,
-                                  @RequestParam(value = "cashingTime") int cashingTime
+                                  @RequestParam(value = "cachingTime") int cachingTime
                                   ) throws IOException {
         SseEmitter emitter = new SseEmitter(600000L);
         try {
             emitter.send(SseEmitter.event().name("INIT").data("이미지 업로드가 시작되었습니다."));
-            uploadService.saveImageMetadata(file, size, cashingTime)
+            uploadService.saveImageMetadata(file, size, cachingTime)
                     .handle((result, ex) -> {
                         try {
                             if (ex == null) {

--- a/upload/src/main/java/image/module/upload/presentation/UploadController.java
+++ b/upload/src/main/java/image/module/upload/presentation/UploadController.java
@@ -29,11 +29,14 @@ public class UploadController {
     private final UploadService uploadService;
 
     @PostMapping
-    public SseEmitter uploadImage(@RequestParam("file") MultipartFile file, @RequestParam(value = "size", required = false) int size) throws IOException {
+    public SseEmitter uploadImage(@RequestParam("file") MultipartFile file,
+                                  @RequestParam(value = "size") int size,
+                                  @RequestParam(value = "cashingTime") int cashingTime
+                                  ) throws IOException {
         SseEmitter emitter = new SseEmitter(600000L);
         try {
             emitter.send(SseEmitter.event().name("INIT").data("이미지 업로드가 시작되었습니다."));
-            uploadService.saveImageMetadata(file, size)
+            uploadService.saveImageMetadata(file, size, cashingTime)
                     .handle((result, ex) -> {
                         try {
                             if (ex == null) {

--- a/upload/src/main/java/image/module/upload/presentation/UploadController.java
+++ b/upload/src/main/java/image/module/upload/presentation/UploadController.java
@@ -29,11 +29,11 @@ public class UploadController {
     private final UploadService uploadService;
 
     @PostMapping
-    public SseEmitter uploadImage(@RequestParam("file") MultipartFile file) throws IOException {
+    public SseEmitter uploadImage(@RequestParam("file") MultipartFile file, @RequestParam(value = "size", required = false) int size) throws IOException {
         SseEmitter emitter = new SseEmitter(600000L);
         try {
             emitter.send(SseEmitter.event().name("INIT").data("이미지 업로드가 시작되었습니다."));
-            uploadService.saveImageMetadata(file)
+            uploadService.saveImageMetadata(file, size)
                     .handle((result, ex) -> {
                         try {
                             if (ex == null) {

--- a/upload/src/main/resources/application.yml
+++ b/upload/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
     bootstrap-servers: kafka:29092
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
-      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
   servlet:
     multipart:
       max-file-size: 1GB # 최대 파일 사이즈


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #60

## 📝작업 내용

> 너비 높이 빼고 size넣기, size는 가로 세로 중 긴 길이 넣기
> size 메시지 담아서 보내기
> 캐싱타임 추가하기
> cdn_url 저장 X


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 이미지 업로드 및 처리에 대한 새로운 필드(`size`, `cachingTime`) 추가.
	- `ImageUploadMessage` 클래스를 통해 이미지 업로드 메시지 세부정보 캡슐화.

- **버그 수정**
	- 이미지 업로드 메서드에서 새로운 매개변수(`size`, `cachingTime`)를 포함하도록 수정.

- **문서화**
	- Kafka 프로듀서 설정에서 직렬화기 변경.

- **리팩토링**
	- `createImage` 메서드 이름을 `saveImage`로 변경하여 기능 명확화.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->