### PR TITLE
FEAT: #67 이미지 다건 업로드 multi upload

### DIFF
--- a/upload/src/main/java/image/module/upload/application/UploadService.java
+++ b/upload/src/main/java/image/module/upload/application/UploadService.java
@@ -87,36 +87,4 @@ public class UploadService {
 
             kafkaTemplate.send("image-upload-topic", ImageUploadMessage.createMessage(image.getStoredFileName(),requestSize));
     }
-
-
-//    @SneakyThrows
-//    public ResponseEntity<byte[]> getImage(String cdnUrl) {
-//        byte[] imageBytes = minioClient.getObject(
-//                GetObjectArgs.builder()
-//                        .bucket(bucketName)
-//                        .object("")
-//                        .build()).readAllBytes();
-//
-//        // 응답 헤더 설정
-//        HttpHeaders headers = new HttpHeaders();
-//        headers.setContentType(MediaType.parseMediaType("image/jpeg"));
-//
-//        return new ResponseEntity<>(imageBytes, headers, HttpStatus.OK);
-//    }
-//
-//    @SneakyThrows
-//    public ResponseEntity<byte[]> downloadImage(String cdnUrl){
-//        byte[] imageBytes = minioClient.getObject(
-//                GetObjectArgs.builder()
-//                        .bucket(bucketName)
-//                        .object("")
-//                        .build()).readAllBytes();
-//
-//        // 응답 헤더 설정
-//        HttpHeaders headers = new HttpHeaders();
-//        headers.setContentType(MediaType.parseMediaType("image/jpeg"));
-//        headers.setContentDispositionFormData("attachment", "test.jpeg");
-//
-//        return new ResponseEntity<>(imageBytes, headers, HttpStatus.OK);
-//    }
 }

--- a/upload/src/main/java/image/module/upload/presentation/UploadController.java
+++ b/upload/src/main/java/image/module/upload/presentation/UploadController.java
@@ -1,18 +1,12 @@
 package image.module.upload.presentation;
 
 import image.module.upload.application.UploadService;
-import image.module.upload.application.ImageResponse;
-import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -43,7 +37,7 @@ public class UploadController {
                                 emitter.send(SseEmitter.event().name("SUCCESS").data("이미지 업로드 완료: " + result));
                                 emitter.complete();
                             } else {
-                                emitter.send(SseEmitter.event().name("ERROR").data("업로드 실패..."));
+                                emitter.send(SseEmitter.event().name("ERROR").data(file.getOriginalFilename() + " 업로드 실패..." + ex.getMessage()));
                                 emitter.completeWithError(ex);
                             }
                         } catch (IOException e) {
@@ -60,13 +54,68 @@ public class UploadController {
         return emitter;
     }
 
-//    @GetMapping("/test")
-//    public ResponseEntity<byte[]> getImage(HttpServletRequest request) {
-//        return uploadService.getImage(request.getRequestURL().toString());
-//    }
-//
-//    @GetMapping("/downloadTest")
-//    public ResponseEntity<byte[]> downloadImage(HttpServletRequest request) {
-//        return uploadService.downloadImage(request.getRequestURL().toString());
-//    }
+    @PostMapping("/multi")
+    public SseEmitter uploadImages(@RequestParam("files") MultipartFile[] files,
+                                   @RequestParam(value = "sizes") int[] sizes,
+                                   @RequestParam(value = "cachingTimes") int[] cachingTimes)  {
+        // 파일 개수와 size, cachingTime 배열 길이가 동일한지 확인
+        if (files.length != sizes.length || files.length != cachingTimes.length) {
+            throw new IllegalArgumentException("파일 개수와 sizes, cachingTimes 배열 길이가 일치하지 않습니다.");
+        }
+
+        SseEmitter emitter = new SseEmitter(600000L);
+        try {
+            emitter.send(SseEmitter.event().name("INIT").data("이미지 업로드가 시작되었습니다."));
+
+            List<CompletableFuture<Void>> futures = new ArrayList<>();
+
+            // 각 파일에 대해 개별적으로 size, cachingTime 적용
+            for (int i = 0; i < files.length; i++) {
+                MultipartFile file = files[i];
+                int size = sizes[i];
+                int cachingTime = cachingTimes[i];
+
+                CompletableFuture<Void> future = uploadService.saveImageMetadata(file, size, cachingTime)
+                        .handle((result, ex) -> {
+                            try {
+                                if (ex == null) {
+                                    // 개별 이미지 업로드 성공 시 알림
+                                    emitter.send(SseEmitter.event().name("SUCCESS").data("이미지 업로드 완료: " + result));
+                                } else {
+                                    // 개별 이미지 업로드 실패 시 알림
+                                    emitter.send(SseEmitter.event().name("ERROR").data(file.getOriginalFilename() + " 업로드 실패: " + ex.getMessage()));
+                                }
+                            } catch (IOException e) {
+                                log.error("IOException 발생", e);
+                                emitter.completeWithError(e);
+                            }
+                            return null;
+                        });
+
+                futures.add(future);
+            }
+
+            // 모든 업로드 작업 완료 후 알림
+            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).thenRun(() -> {
+                try {
+                    emitter.send(SseEmitter.event().name("COMPLETE").data("모든 이미지 업로드 작업이 완료되었습니다."));
+                    emitter.complete();
+                } catch (IOException e) {
+                    log.error("IOException 발생", e);
+                    emitter.completeWithError(e);
+                }
+            });
+
+        } catch (Exception e) {
+            try {
+                emitter.send(SseEmitter.event().name("ERROR").data("업로드 실패..."));
+            } catch (IOException ioException) {
+                log.error("IOException 발생", ioException);
+            }
+            emitter.completeWithError(e);
+        }
+
+        return emitter;
+    }
+
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #67

## 📝작업 내용

> 이미지 multi 업로드 구현

![image](https://github.com/user-attachments/assets/ee8ded3d-7575-4364-97e5-dc36d3a4064c)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 여러 이미지를 동시에 업로드할 수 있는 기능 추가.
	- 업로드 중 오류 발생 시 원본 파일 이름과 오류 메시지를 포함한 개선된 오류 보고 기능.
- **버그 수정**
	- 업로드 이미지 메서드의 예외 처리 강화.
- **제거된 기능**
	- 이미지 검색 및 다운로드 메서드 제거.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->