### PR TITLE
[Feat] #85 header 인코딩 및 리사이징 이미지 cdn ur 반환

### DIFF
--- a/data/src/main/java/image/module/data/application/ImageService.java
+++ b/data/src/main/java/image/module/data/application/ImageService.java
@@ -64,4 +64,11 @@ public class ImageService {
 
     }
 
+    // 이미지 resizing cdn url 반환 g
+    public ImageResponse getReCdnUrl(UUID originalFileUUID, Integer size) {
+        Image image = imageRepository.findByOriginalFileUuidAndSize(originalFileUUID, size)
+                .orElseThrow(() -> new RuntimeException("이미지를 찾을 수 없습니다."));
+
+        return ImageResponse.fromEntity(image);
+    }
 }

--- a/data/src/main/java/image/module/data/domain/repository/ImageRepository.java
+++ b/data/src/main/java/image/module/data/domain/repository/ImageRepository.java
@@ -5,8 +5,14 @@ import image.module.data.domain.Image;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ImageRepository extends JpaRepository<Image, UUID> {
     Image findByCdnUrl(String cdnUrl);
   Optional<Image> findByStoredFileName(String storedFileName);
+
+    @Query("SELECT i FROM image i WHERE i.originalFileUUID = :originalFileUuid AND i.size = :size")
+    Optional<Image> findByOriginalFileUuidAndSize(@Param("originalFileUuid") UUID originalFileUuid,
+                                                  @Param("size") Integer size);
 }

--- a/data/src/main/java/image/module/data/presentation/ImageController.java
+++ b/data/src/main/java/image/module/data/presentation/ImageController.java
@@ -54,4 +54,11 @@ public class ImageController {
         imageService.creatImage(createResizeRequest); // Image 업데이트 로직
 
     }
+
+    //원본 uuid 와 size의 cdn url 반환
+    @GetMapping("/image/getReCdnUrl")
+    public ImageResponse getReCdnUrl(@RequestParam("originalFileUUID") UUID originalFileUUID,
+                                     @RequestParam("size") Integer size){
+        return imageService.getReCdnUrl(originalFileUUID,size);
+    }
 }

--- a/url/src/main/java/image/module/url/client/data/DataClient.java
+++ b/url/src/main/java/image/module/url/client/data/DataClient.java
@@ -2,7 +2,6 @@ package image.module.url.client.data;
 
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.UUID;
@@ -24,5 +23,9 @@ public interface DataClient extends DataService {
     ImageResponse getCDNImageName(@RequestParam("cdnUrl") String cdnUrl);
 
 
+    //resizing 된 cdn url 반환
+    @GetMapping("/image/getReCdnUrl")
+    ImageResponse getReCdnUrl(@RequestParam("originalFileUUID") UUID originalFileUUID,
+                              @RequestParam("size") Integer size);
     }
 

--- a/url/src/main/java/image/module/url/client/data/DataService.java
+++ b/url/src/main/java/image/module/url/client/data/DataService.java
@@ -1,8 +1,6 @@
 package image.module.url.client.data;
 
 
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.UUID;
 
@@ -13,5 +11,7 @@ public interface DataService{
 
     //이미지 cdn -> 이름 조회
     ImageResponse getCDNImageName(String cdnUrl);
+
+    ImageResponse getReCdnUrl(UUID originalFileUUID,Integer size);
 
 }

--- a/url/src/main/java/image/module/url/controller/UrlController.java
+++ b/url/src/main/java/image/module/url/controller/UrlController.java
@@ -1,7 +1,6 @@
 package image.module.url.controller;
 
-import image.module.url.client.data.DataService;
-import image.module.url.client.data.ImageResponse;
+
 import image.module.url.service.UrlService;
 import java.util.UUID;
 import lombok.extern.log4j.Log4j2;
@@ -16,34 +15,30 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/fetch")
 public class UrlController {
 
-    private final DataService dataService;
+
     private final UrlService urlService;
 
 
-    public UrlController(DataService dataService, UrlService urlService) {
-        this.dataService = dataService;
+    public UrlController( UrlService urlService) {
         this.urlService = urlService;
     }
 
 
-   //uuid 조회시 cdn Url 반환
+    //uuid 조회시 cdn Url 반환
     @GetMapping("/cdnUrl")
-    public ResponseEntity<String> getImage(@RequestParam("id") UUID id) {
+    public ResponseEntity<String> getImage(@RequestParam("id") UUID id,
+                                           @RequestParam(value = "size", required = false ) Integer size){
 
-        // 1. UUID로 cdnUrl 조회
-        ImageResponse imageResponse = dataService.getImageName(id);
 
-        // cdnUrl이 null인지 확인
-        if (imageResponse == null || imageResponse.getCdnUrl() == null) {
-            String message = "이미지를 찾을 수 없거나 CDN URL이 없습니다.";
-            log.warn(message);
-            return ResponseEntity.ok(message); // 200 OK와 함께 메시지 반환
+
+        //원본 : size null 일 때
+        if(size==null){
+            return urlService.getCdnUrl(id);
         }
 
-        String cdnUrl = imageResponse.getCdnUrl();
-        log.info("CDN URL: {}", cdnUrl);
+        //리사이징 된 이미지 조회
 
-        return ResponseEntity.ok(cdnUrl); // 정상적으로 CDN URL 반환
+        return urlService.getReCdnUrl(id, size);
     }
 
 

--- a/url/src/main/java/image/module/url/service/UrlService.java
+++ b/url/src/main/java/image/module/url/service/UrlService.java
@@ -11,6 +11,7 @@ import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.UUID;
 import javax.imageio.ImageIO;
 import lombok.RequiredArgsConstructor;
@@ -68,7 +69,7 @@ public class UrlService {
 
             // 헤더 설정
             HttpHeaders headers = new HttpHeaders();
-            String encodedFileName = URLEncoder.encode(imageResponse.getOriginalFileName(), StandardCharsets.UTF_8);
+            String encodedFileName = Base64.getEncoder().encodeToString(imageResponse.getOriginalFileName().getBytes(StandardCharsets.UTF_8));
             headers.add("fileName", encodedFileName);
             headers.add("File-Type", imageResponse.getFileType());
             headers.add("cache-time", imageResponse.getCachingTime().toString());

--- a/url/src/main/java/image/module/url/service/UrlService.java
+++ b/url/src/main/java/image/module/url/service/UrlService.java
@@ -11,6 +11,7 @@ import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.UUID;
 import javax.imageio.ImageIO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -45,13 +46,10 @@ public class UrlService {
 
 
             // 조회한 이미지에서 storedFileName , originalFileName , fileType 조회
-            String fileName = imageResponse.getOriginalFileName();
+
             String storegeFileName = imageResponse.getStoredFileName();
             String fileType = imageResponse.getFileType();
-            Integer cache = imageResponse.getCachingTime();
 
-            log.info("저장된 파일명: {}", fileName);
-            log.info("파일 타입: {}", fileType);
 
             // file type이 webp이면 minio bucket uploadBucket으로 조회, 그 외는 downloadBucket에서 조회
             String bucketToUse = fileType.equalsIgnoreCase("webp") ? uploadBucket : downloadBucket;
@@ -67,12 +65,13 @@ public class UrlService {
             }
 
             log.info("이미지 바이트 길이: {}", imageBytes.length);
-            // 헤더 설정
+
             // 헤더 설정
             HttpHeaders headers = new HttpHeaders();
-            headers.add("fileName", fileName);
-            headers.add("File-Type", fileType);
-            headers.add("cache-time", cache.toString());
+            String encodedFileName = URLEncoder.encode(imageResponse.getOriginalFileName(), StandardCharsets.UTF_8);
+            headers.add("fileName", encodedFileName);
+            headers.add("File-Type", imageResponse.getFileType());
+            headers.add("cache-time", imageResponse.getCachingTime().toString());
             headers.setContentType(MediaType.APPLICATION_OCTET_STREAM);
 
 
@@ -135,10 +134,36 @@ public class UrlService {
         return outputStream.toByteArray();
     }
 
+  // 원본 cdn url 조회
+    public ResponseEntity<String> getCdnUrl(UUID id) {
+        ImageResponse imageResponse = dataService.getImageName(id);
+
+            // cdnUrl이 null인지 확인
+            if (imageResponse == null) {
+                String message = "이미지를 찾을 수 없거나 CDN URL이 없습니다.";
+                log.warn(message);
+                return ResponseEntity.ok(message); // 200 OK와 함께 메시지 반환
+            }
+
+            String cdnUrl = imageResponse.getCdnUrl();
+            log.info("CDN URL: {}", cdnUrl);
+
+            return ResponseEntity.ok(cdnUrl); // 정상적으로 CDN URL 반환
+    }
+
+    public ResponseEntity<String> getReCdnUrl(UUID originalFileUUID, Integer size) {
+
+        log.info("fetch service : uuid"+originalFileUUID+"size"+size);
+        ImageResponse imageResponse = dataService.getReCdnUrl(originalFileUUID,size);
+
+        if(imageResponse == null) {
+            String message ="이미지를 찾을 수 없거나 CDN URL 이 없습니다.";
+            log.warn(message);
+            return ResponseEntity.ok(message);
+        }
+
+        return ResponseEntity.ok(imageResponse.getCdnUrl());
 
 
-
-
-
-
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #85 

## 📝작업 내용

> header 에 FileName 추가시 인코딩 해서 넘겨주기 
> 

**원본 이미지 조회**

->클라이언트가 CDN URL을 통해 UUID를 파라미터로 전달하면, 해당 UUID에 대한 원본 이미지를 조회하여 반환합니다.

**리사이징된 이미지 조회**

->클라이언트가 리사이징된 이미지의 CDN URL을 요청할 때, UUID와 변경된 사이즈 값을 파라미터로 전달하면, 해당 사이즈로 리사이징된 이미지의 CDN URL을 반환합니다.

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
	- 원본 파일 UUID와 크기를 기반으로 CDN URL을 검색하는 새로운 API 엔드포인트 추가.
	- 이미지 리사이징을 위한 CDN URL을 반환하는 메서드 추가.
	- URL 서비스의 기능 향상 및 오류 처리 개선.
- **버그 수정**
	- 이미지 메타데이터 처리 개선 및 오류 처리 유지.
- **문서화**
	- API 사용법에 대한 업데이트된 설명 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->